### PR TITLE
Provide overlay

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /result
 /result-*
 /target
+
+# direnv
+.direnv

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,66 @@
+{ pkgs
+, lib
+, darwin
+, installShellFiles
+, makeBinaryWrapper
+, rustPlatform
+, stdenv
+}:
+let
+  inherit (lib) makeBinPath optionals;
+
+  runtimeInputs = with pkgs; [
+    gitMinimal
+    mercurial
+    nixVersions.unstable
+  ];
+
+  src = lib.sourceByRegex ./. [
+    "(src|tests)(/.*)?"
+    "Cargo\\.(toml|lock)"
+    "build.rs"
+  ];
+  inherit (lib.importTOML (./Cargo.toml)) package;
+in
+rustPlatform.buildRustPackage rec  {
+  inherit src;
+  inherit (package) version;
+  pname = package.name;
+
+  cargoLock = {
+    allowBuiltinFetchGit = true;
+    lockFile = src + "/Cargo.lock";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
+
+  buildInputs = optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  # tests require internet access
+  doCheck = false;
+
+  env = {
+    GEN_ARTIFACTS = "artifacts";
+  };
+
+  postInstall = ''
+    wrapProgram $out/bin/nurl --prefix PATH : ${makeBinPath runtimeInputs}
+    installManPage artifacts/nurl.1
+    installShellCompletion artifacts/nurl.{bash,fish} --zsh artifacts/_nurl
+  '';
+
+  meta =
+    let
+      inherit (lib) licenses maintainers;
+    in
+    {
+      inherit (package) description;
+      license = licenses.mpl20;
+      maintainers = with maintainers; [ figsoda ];
+    };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,4 @@
+final: prev:
+{
+  nurl = (final.callPackage ./default.nix { });
+}


### PR DESCRIPTION
Moved `packages.default` in `flake.nix` to `default.nix` and provide overlay for easier handling.

I was not sure from the source code whether mecurial and other `runtimeInputs` were really needed at runtime, but I left them as they were for now.

This PR including adding `.envrc` and  editing `.gitignore` for direnv, but you can remove them if you don't like them.