### PR TITLE
Add 'flakes' to extra experimental features

### DIFF
--- a/src/prefetch.rs
+++ b/src/prefetch.rs
@@ -93,7 +93,7 @@ pub fn url_prefetch(url: String, unpack: bool) -> Result<String> {
 
 pub fn fod_prefetch(expr: String) -> Result<String> {
     info!(
-        "$ nix build --extra-experimental-features nix-command --impure --no-link --expr '{expr}'"
+        "$ nix build --extra-experimental-features 'nix-command flakes' --impure --no-link --expr '{expr}'"
     );
 
     let Output {
@@ -103,7 +103,7 @@ pub fn fod_prefetch(expr: String) -> Result<String> {
     } = Command::new("nix")
         .arg("build")
         .arg("--extra-experimental-features")
-        .arg("nix-command")
+        .arg("nix-command flakes")
         .arg("--impure")
         .arg("--no-link")
         .arg("--expr")


### PR DESCRIPTION
In my flake setup, I use `flake:` for my nixPaths because I wanted compatibility with legacy commands. However, this didn't work well with nurl when I was using it - 

```
[hubble@Gulo-Laptop:/run/media/hubble/Data/GithubFurry/nurl]$ nurl --fetcher fetchFromGitea https://projects.blender.org/blender/blender-addons v3.6.5 --arg-str postFetch 'patch -p3 -d $out < ${./draco-p2.patch}'
$ nix build --experimental-features nix-command --impure --no-link --expr '(import(<nixpkgs>){}).fetchFromGitea{domain="projects.blender.org";owner="blender";repo="blender-addons";rev="v3.6.5";hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";postFetch="patch -p3 -d $out < ${./draco-p2.patch}";}'
Error: failed to find the hash from error messages
stdout: 
stderr:
error:
       … while calling the 'import' builtin

         at «string»:1:2:

            1| (import(<nixpkgs>){}).fetchFromGitea{domain="projects.blender.org";owner="blender";repo="blender-addons";rev="v3.6.5";hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";postFetch="patch -p3 -d $out < ${./draco-p2.patch}";}
             |  ^

       … while calling the 'findFile' builtin

         at «string»:1:9:

            1| (import(<nixpkgs>){}).fetchFromGitea{domain="projects.blender.org";owner="blender";repo="blender-addons";rev="v3.6.5";hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";postFetch="patch -p3 -d $out < ${./draco-p2.patch}";}
             |         ^

       error: experimental Nix feature 'flakes' is disabled; use '--extra-experimental-features flakes' to override
```
... particularly in for `fod_prefetch`.

With this PR:
```
[hubble@Gulo-Laptop:/run/media/hubble/Data/GithubFurry/nixpkgs/pkgs/applications/misc/blender]$ nurl --fetcher fetchFromGitea https://projects.blender.org/blender/blender-addons v3.6.5 --arg-str postFetch 'patch -p3 -d $out < ${./draco-p2.patch}'
$ nix build --extra-experimental-features 'nix-command flakes' --impure --no-link --expr '(import(<nixpkgs>){}).fetchFromGitea{domain="projects.blender.org";owner="blender";repo="blender-addons";rev="v3.6.5";hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";postFetch="patch -p3 -d $out < ${./draco-p2.patch}";}'
fetchFromGitea {
  domain = "projects.blender.org";
  owner = "blender";
  repo = "blender-addons";
  rev = "v3.6.5";
  hash = "sha256-K4jbWuWaXtSjEqbmZC+7SnsNUJCcru1U1HuI4LCuuGM=";
  postFetch = "patch -p3 -d $out < ${./draco-p2.patch}";
}
```

Let me know if this is an acceptable solution for this problem 