### PR TITLE
Make package overridable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708296515,
-        "narHash": "sha256-FyF489fYNAUy7b6dkYV6rGPyzp+4tThhr80KNAaF/yY=",
+        "lastModified": 1716769173,
+        "narHash": "sha256-7EXDb5WBw+d004Agt+JHC/Oyh/KTUglOaQ4MNjBbo5w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa",
+        "rev": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
             , stdenv
             , gitMinimal
             , mercurial
-            , nixUnstable
+            , nix
             , ...
             }: rustPlatform.buildRustPackage rec {
               pname = "nurl";
@@ -63,7 +63,7 @@
               runtimeInputs = [
                 gitMinimal
                 mercurial
-                nixUnstable
+                nix
               ];
 
               nativeBuildInputs = [


### PR DESCRIPTION
I used `callPackage` to make  the package overridable instead of the function you used. I tried as much as possible to keep everything as it was.

I also had to change the specified nix package because of `nixVersions.unstable` getting removed in unstable after updating the `flake.lock`.