### PR TITLE
{fetchhg,fetchsvn}: sha256 -> hash

### DIFF
--- a/src/fetcher/hg.rs
+++ b/src/fetcher/hg.rs
@@ -6,7 +6,6 @@ pub struct Fetchhg(pub bool);
 impl_fetcher!(Fetchhg);
 
 impl<'a> SimpleFetcher<'a, 1> for Fetchhg {
-    const HASH_KEY: &'static str = "sha256";
     const KEYS: [&'static str; 1] = ["url"];
     const NAME: &'static str = "fetchhg";
     const SUBMODULES_KEY: Option<&'static str> = Some("fetchSubrepos");

--- a/src/fetcher/svn.rs
+++ b/src/fetcher/svn.rs
@@ -7,7 +7,6 @@ pub struct Fetchsvn;
 impl_fetcher!(Fetchsvn);
 
 impl<'a> SimpleFetcher<'a, 1> for Fetchsvn {
-    const HASH_KEY: &'static str = "sha256";
     const KEYS: [&'static str; 1] = ["url"];
     const NAME: &'static str = "fetchsvn";
 

--- a/tests/cmd/fetcher/hg/basic.stdout
+++ b/tests/cmd/fetcher/hg/basic.stdout
@@ -1,5 +1,5 @@
 fetchhg {
   url = "https://hg.sr.ht/~scoopta/wofi";
   rev = "v1.3";
-  sha256 = "sha256-GxMjEXBPQniD+Yc9QZjd8TH4ILJAX5dNzrjxDawhy8w=";
+  hash = "sha256-GxMjEXBPQniD+Yc9QZjd8TH4ILJAX5dNzrjxDawhy8w=";
 }

--- a/tests/cmd/fetcher/hg/scheme_plus.stdout
+++ b/tests/cmd/fetcher/hg/scheme_plus.stdout
@@ -1,5 +1,5 @@
 fetchhg {
   url = "https://hg.sr.ht/~scoopta/wofi";
   rev = "v1.3";
-  sha256 = "sha256-GxMjEXBPQniD+Yc9QZjd8TH4ILJAX5dNzrjxDawhy8w=";
+  hash = "sha256-GxMjEXBPQniD+Yc9QZjd8TH4ILJAX5dNzrjxDawhy8w=";
 }

--- a/tests/cmd/fetcher/svn.stdout
+++ b/tests/cmd/fetcher/svn.stdout
@@ -1,5 +1,5 @@
 fetchsvn {
   url = "svn://svn.mplayerhq.hu/mplayer/trunk";
   rev = "30000";
-  sha256 = "sha256-gmiB9GR2VfzTzdIWe6kVCldaau6Cq0F9J0exFZChT1o=";
+  hash = "sha256-gmiB9GR2VfzTzdIWe6kVCldaau6Cq0F9J0exFZChT1o=";
 }

--- a/tests/cmd/submodules/hg.stdout
+++ b/tests/cmd/submodules/hg.stdout
@@ -1,6 +1,6 @@
 fetchhg {
   url = "https://hg.sr.ht/~scoopta/wofi";
   rev = "v1.5.1";
-  sha256 = "sha256-r+p8WDJw8aO1Gdgy6+UwT5QJdejIjcPFSs/Gfzq+D/c=";
+  hash = "sha256-r+p8WDJw8aO1Gdgy6+UwT5QJdejIjcPFSs/Gfzq+D/c=";
   fetchSubrepos = true;
 }


### PR DESCRIPTION
they now support the hash attribute

fetchHex is now the only fetcher we support that doesn't support the hash attribute